### PR TITLE
Fix #43 and #39

### DIFF
--- a/Sources/Graphaello/Commands/checkVersion.swift
+++ b/Sources/Graphaello/Commands/checkVersion.swift
@@ -26,7 +26,7 @@ private struct HomebrewInfo: Decodable {
 
 private func fetchInstalledVersion() -> String? {
     let task = Process()
-    task.launchPath = "/usr/local/bin/brew"
+    task.launchPath = ExecutableFinder.find("brew")?.url.path
     task.arguments = ["info", "graphaello", "--json"]
 
     let outputPipe = Pipe()


### PR DESCRIPTION
This should hopefully fix #43 and #39. It uses `ExecutableFinder.find` to find Homebrew.